### PR TITLE
Add checking a custom domain in each environment

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -50,7 +50,12 @@ cp -R \
 
 # Write manifest
 cp "${ORIG_PWD}/src/manifest-template.yml" "${ORIG_PWD}/manifest/manifest.yml"
-printf "\ndomain: system.$DOMAIN\n" >> "${ORIG_PWD}/manifest/manifest.yml"
+cat <<EOF >> ${ORIG_PWD}/manifest/manifest.yml
+routes:
+- route: cf-healthcheck.system.${DOMAIN} # route with the system wildcard cert
+- route: cf-healthcheck.${DOMAIN}        # route with a custom cert
+EOF
+
 
 # Write SHA256
 EXPECTED_RESULT="$(openssl dgst -sha256 < "${ORIG_PWD}/src/data/status.json" | sed 's/^.* //')"

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -67,9 +67,14 @@ set -x
 set -o pipefail
 set -u
 
-RESULT="\$(curl "http://cf-healthcheck.system.${DOMAIN}" | openssl dgst -sha256 | sed 's/^.* //')"
+SYSTEM_RESULT="\$(curl "https://cf-healthcheck.system.${DOMAIN}" | openssl dgst -sha256 | sed 's/^.* //')"
 
-[[ "\${RESULT}" == "${EXPECTED_RESULT}" ]] || exit 1
+[[ "\${SYSTEM_RESULT}" == "${EXPECTED_RESULT}" ]] || exit 1
+
+CUSTOM_DOMAIN_RESULT="\$(curl "https://cf-healthcheck.${DOMAIN}" | openssl dgst -sha256 | sed 's/^.* //')"
+
+[[ "\${CUSTOM_DOMAIN_RESULT}" == "${EXPECTED_RESULT}" ]] || exit 1
+
 EOF
 
 chmod a+x "${ORIG_PWD}/test/check.sh"

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -50,7 +50,7 @@ cp -R \
 
 # Write manifest
 cp "${ORIG_PWD}/src/manifest-template.yml" "${ORIG_PWD}/manifest/manifest.yml"
-printf "\ndomain: $DOMAIN\n" >> "${ORIG_PWD}/manifest/manifest.yml"
+printf "\ndomain: system.$DOMAIN\n" >> "${ORIG_PWD}/manifest/manifest.yml"
 
 # Write SHA256
 EXPECTED_RESULT="$(openssl dgst -sha256 < "${ORIG_PWD}/src/data/status.json" | sed 's/^.* //')"
@@ -62,7 +62,7 @@ set -x
 set -o pipefail
 set -u
 
-RESULT="\$(curl "http://cf-healthcheck.${DOMAIN}" | openssl dgst -sha256 | sed 's/^.* //')"
+RESULT="\$(curl "http://cf-healthcheck.system.${DOMAIN}" | openssl dgst -sha256 | sed 's/^.* //')"
 
 [[ "\${RESULT}" == "${EXPECTED_RESULT}" ]] || exit 1
 EOF

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -10,7 +10,7 @@ jobs:
     - task: build
       file: src/ci/build.yml
       params:
-        DOMAIN: system.b.cld.gov.au
+        DOMAIN: b.cld.gov.au
     - put: b-cf
       params:
         manifest: manifest/manifest.yml
@@ -37,7 +37,7 @@ jobs:
     - task: build
       file: src/ci/build.yml
       params:
-        DOMAIN: system.d.cld.gov.au
+        DOMAIN: d.cld.gov.au
     - put: d-cf
       params:
         manifest: manifest/manifest.yml
@@ -64,7 +64,7 @@ jobs:
     - task: build
       file: src/ci/build.yml
       params:
-        DOMAIN: system.g.cld.gov.au
+        DOMAIN: g.cld.gov.au
     - put: g-cf
       params:
         manifest: manifest/manifest.yml
@@ -91,7 +91,7 @@ jobs:
     - task: build
       file: src/ci/build.yml
       params:
-        DOMAIN: system.y.cld.gov.au
+        DOMAIN: y.cld.gov.au
     - put: y-cf
       params:
         manifest: manifest/manifest.yml
@@ -118,7 +118,7 @@ jobs:
     - task: probe
       file: src/ci/probe.yml
       params:
-        DOMAIN: system.b.cld.gov.au
+        DOMAIN: b.cld.gov.au
     on_failure:
       put: slack
       params:
@@ -136,7 +136,7 @@ jobs:
     - task: probe
       file: src/ci/probe.yml
       params:
-        DOMAIN: system.d.cld.gov.au
+        DOMAIN: d.cld.gov.au
     on_failure:
       put: slack
       params:
@@ -154,7 +154,7 @@ jobs:
     - task: probe
       file: src/ci/probe.yml
       params:
-        DOMAIN: system.g.cld.gov.au
+        DOMAIN: g.cld.gov.au
     on_failure:
       put: slack
       params:
@@ -172,7 +172,7 @@ jobs:
     - task: probe
       file: src/ci/probe.yml
       params:
-        DOMAIN: system.y.cld.gov.au
+        DOMAIN: y.cld.gov.au
     on_failure:
       put: slack
       params:

--- a/ci/probe.sh
+++ b/ci/probe.sh
@@ -5,4 +5,4 @@ set -x
 set -o pipefail
 set -u
 
-curl -v -f "https://cf-healthcheck.${DOMAIN}/"
+curl -v -f "https://cf-healthcheck.system.${DOMAIN}/"

--- a/ci/probe.sh
+++ b/ci/probe.sh
@@ -6,3 +6,4 @@ set -o pipefail
 set -u
 
 curl -v -f "https://cf-healthcheck.system.${DOMAIN}/"
+curl -v -f "https://cf-healthcheck.${DOMAIN}/"


### PR DESCRIPTION
This PR adds a new route cf-healthcheck.x.cld.gov.au to the cf-healthcheck app in each environment and tests this new endpoint.
I have already created the custom domain in each environment (eg `cfd create-domain system cf-healthcheck.d.cld.gov.au`), and added the cert.